### PR TITLE
Quote eval-after-load form.

### DIFF
--- a/ac-nim.el
+++ b/ac-nim.el
@@ -62,7 +62,7 @@
 
 ;;;###autoload
 (eval-after-load 'auto-complete
-  (add-to-list 'ac-modes 'nim-mode))
+  '(add-to-list 'ac-modes 'nim-mode))
 
 ;;;###autoload
 (defun ac-nim-enable ()


### PR DESCRIPTION
`eval-after-load` second argument must be a quoted form.